### PR TITLE
chore: switch to localizer-cldr to deal with module/package issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@ as much as possible, since it takes care of some difficult tasks.
 
 ## Getting Started: Example
 ```go
+package main
+
 import (
     "fmt"
     "time"
 
-    "github.com/razor-1/cldr/resources/currency"
     "golang.org/x/text/language"
 
     "github.com/razor-1/localizer"
+	"github.com/razor-1/localizer-cldr/resources/currency"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/leonelquinteros/gotext v1.5.0
-	github.com/razor-1/cldr v0.2.0
+	github.com/razor-1/localizer-cldr v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/text v0.3.7
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/leonelquinteros/gotext v1.5.0 h1:ODY7LzLpZWWSJdAHnzhreOr6cwLXTAmc914F
 github.com/leonelquinteros/gotext v1.5.0/go.mod h1:OCiUVHuhP9LGFBQ1oAmdtNCHJCiHiQA8lf4nAifHkr0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/razor-1/cldr v0.2.0 h1:rTbiZUr43ZRWfpeBPa8fXIXDETstZo9Lf7DWMX0OhoA=
-github.com/razor-1/cldr v0.2.0/go.mod h1:DW7bKH2W6ThJcJcpWQmyhyyL0NInlvMAaVwojaMypZk=
+github.com/razor-1/localizer-cldr v0.2.0 h1:GAAWNtL3pS++mHtWAB4EF/55bw7IY2xeOnucdXhdJf8=
+github.com/razor-1/localizer-cldr v0.2.0/go.mod h1:urcdU6Zwv/mAWElxdfzwzLqFpC69K1clnwYQsvau79A=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/locale.go
+++ b/locale.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/razor-1/cldr"
-	"github.com/razor-1/cldr/resources"
+	"github.com/razor-1/localizer-cldr"
+	"github.com/razor-1/localizer-cldr/resources"
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 	"golang.org/x/text/message/catalog"


### PR DESCRIPTION
There was seemingly unretractable history on razor-1/cldr which caused some ambiguous issues when importing it. Moving to localizer-cldr will resolve this.